### PR TITLE
Minor change: Generate Project Skeleton using NTAF as global command

### DIFF
--- a/bin/ntaf.js
+++ b/bin/ntaf.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const fs = require('fs-extra');
+const path = require('path');
+
 
 const emptyDirectories = [
   'src/features',
@@ -21,9 +23,11 @@ const onError = function (err) {
 
 console.log('Creating test project structure...');
 
+var moduleDir = path.join(__dirname, '/../');
+
 const allPromises = [
-  fs.copy('node_modules/ntaf/template/', '.'),
-  fs.copy('node_modules/ntaf/Readme.md', 'Readme.md'),
+  fs.copy(moduleDir + '/template/', '.'),
+  fs.copy(moduleDir + '/Readme.md', 'Readme.md'),
 ];
 
 emptyDirectories.forEach(directory => {


### PR DESCRIPTION
How to Reproduce:
- Install ntaf as a global module (npm install -g ntaf)
- Create a folder where to generate project skeleton

generation doesn't work when:
>> ntaf 
(or: >> node /var/global/node_modules/ntaf/bin/ntaf.j)

Current issue: { Error: ENOENT: no such file or directory,