### PR TITLE
Update generic-browser-commands.js

### DIFF
--- a/lib/browser-command/generic-browser-commands.js
+++ b/lib/browser-command/generic-browser-commands.js
@@ -7,8 +7,8 @@
 const genericBrowserCommands = {
 
   /**
-   * @function waitForVisible
-   * @desc waitForVisible on multiple elements
+   * @function waitForAllVisible
+   * @desc Similar to waitForVisible from webdriverio but on multiple elements
    * @since 1.0.0
    * @param {string[]} elements - Array of elements that are CSS selectors
    * @returns {Promise}


### PR DESCRIPTION
In the JSDoc the function name is wrong, it should be "waitForAllVisible" instead of "waitForVisible"